### PR TITLE
fix getActivatableToggleByName putting visibility in to the isActive parameter

### DIFF
--- a/src/Toggle/MysqlActivatableToggleGateway.php
+++ b/src/Toggle/MysqlActivatableToggleGateway.php
@@ -45,7 +45,7 @@ class MysqlActivatableToggleGateway implements ActivatableToggleGateway
         if ( empty( $data ) ) {
             return null;
         }
-        $toggle = new Toggle( $data[ 'id' ], $data[ 'name' ], $data[ 'release_id' ], (bool)$data[ 'visible' ] );
+        $toggle = new Toggle( $data[ 'id' ], $data[ 'name' ], $data[ 'release_id' ], (bool)$data[ 'active' ] );
 
         return $toggle;
     }


### PR DESCRIPTION
This is a pretty dodgy bug, but luckily not getting used by the frontend/api yet
